### PR TITLE
Replace deprecated part and fix hinge train script.

### DIFF
--- a/main_binary_hinge.py
+++ b/main_binary_hinge.py
@@ -234,7 +234,7 @@ def forward(data_loader, model, criterion, epoch=0, training=True, optimizer=Non
         # measure data loading time
         data_time.update(time.time() - end)
         if args.gpus is not None:
-            target = target.cuda(async=True)
+            target = target.cuda()
         #import pdb; pdb.set_trace()
         if  criterion.__class__.__name__=='HingeLoss':
             target=target.unsqueeze(1)

--- a/main_binary_hinge.py
+++ b/main_binary_hinge.py
@@ -68,12 +68,14 @@ parser.add_argument('-e', '--evaluate', type=str, metavar='FILE',
 
 torch.cuda.random.manual_seed_all(10)
 
+output_dim = 0
 
 
 def main():
-    global args, best_prec1
+    global args, best_prec1, output_dim
     best_prec1 = 0
     args = parser.parse_args()
+    output_dim = {'cifar10': 10, 'cifar100':100, 'imagenet': 1000}[args.dataset]
     #import pdb; pdb.set_trace()
     #torch.save(args.batch_size/(len(args.gpus)/2+1),'multi_gpu_batch_size')
     if args.evaluate:
@@ -101,11 +103,12 @@ def main():
     # create model
     logging.info("creating model %s", args.model)
     model = models.__dict__[args.model]
-    model_config = {'input_size': args.input_size, 'dataset': args.dataset}
+
+
+    model_config = {'input_size': args.input_size, 'dataset': args.dataset, 'num_classes': output_dim}
 
     if args.model_config is not '':
         model_config = dict(model_config, **literal_eval(args.model_config))
-
     model = model(**model_config)
     logging.info("created model with configuration: %s", model_config)
 
@@ -174,7 +177,7 @@ def main():
     optimizer = torch.optim.SGD(model.parameters(), lr=args.lr)
     logging.info('training regime: %s', regime)
     #import pdb; pdb.set_trace()
-    search_binarized_modules(model)
+    #search_binarized_modules(model)
 
     for epoch in range(args.start_epoch, args.epochs):
         optimizer = adjust_optimizer(optimizer, epoch, regime)
@@ -238,26 +241,35 @@ def forward(data_loader, model, criterion, epoch=0, training=True, optimizer=Non
         #import pdb; pdb.set_trace()
         if  criterion.__class__.__name__=='HingeLoss':
             target=target.unsqueeze(1)
-            target_onehot = torch.cuda.FloatTensor(target.size(0), 10)
+            target_onehot = torch.cuda.FloatTensor(target.size(0), output_dim)
             target_onehot.fill_(-1)
             target_onehot.scatter_(1, target, 1)
             target=target.squeeze()
-        input_var = Variable(inputs.type(args.type), volatile=not training)
-        target_var = Variable(target_onehot)
+        if not training:
+            with torch.no_grad():
+                input_var = Variable(inputs.type(args.type))
+                target_var = Variable(target_onehot)
 
-        # compute output
-        output = model(input_var)
+                # compute output
+                output = model(input_var)
+        else:
+                input_var = Variable(inputs.type(args.type))
+                target_var = Variable(target_onehot)
+
+                # compute output
+                output = model(input_var)
+
         #import pdb; pdb.set_trace()
-        loss = criterion(output, target_var)
+        loss = criterion(output, target_onehot)
         #import pdb; pdb.set_trace()
         if type(output) is list:
             output = output[0]
 
         # measure accuracy and record loss
         prec1, prec5 = accuracy(output.data, target, topk=(1, 5))
-        losses.update(loss.data[0], inputs.size(0))
-        top1.update(prec1[0], inputs.size(0))
-        top5.update(prec5[0], inputs.size(0))
+        losses.update(loss.item(), inputs.size(0))
+        top1.update(prec1.item(), inputs.size(0))
+        top5.update(prec5.item(), inputs.size(0))
         #import pdb; pdb.set_trace()
         #if not training and top1.avg<15:
         #    import pdb; pdb.set_trace()

--- a/main_mnist.py
+++ b/main_mnist.py
@@ -121,20 +121,21 @@ def train(epoch):
         if batch_idx % args.log_interval == 0:
             print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
                 epoch, batch_idx * len(data), len(train_loader.dataset),
-                100. * batch_idx / len(train_loader), loss.data[0]))
+                100. * batch_idx / len(train_loader), loss.item()))
 
 def test():
     model.eval()
     test_loss = 0
     correct = 0
-    for data, target in test_loader:
-        if args.cuda:
-            data, target = data.cuda(), target.cuda()
-        data, target = Variable(data, volatile=True), Variable(target)
-        output = model(data)
-        test_loss += criterion(output, target).data[0] # sum up batch loss
-        pred = output.data.max(1, keepdim=True)[1] # get the index of the max log-probability
-        correct += pred.eq(target.data.view_as(pred)).cpu().sum()
+    with torch.no_grad():
+        for data, target in test_loader:
+            if args.cuda:
+                data, target = data.cuda(), target.cuda()
+            data, target = Variable(data), Variable(target)
+            output = model(data)
+            test_loss += criterion(output, target).item() # sum up batch loss
+            pred = output.data.max(1, keepdim=True)[1] # get the index of the max log-probability
+            correct += pred.eq(target.data.view_as(pred)).cpu().sum()
 
     test_loss /= len(test_loader.dataset)
     print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(

--- a/models/alexnet.py
+++ b/models/alexnet.py
@@ -74,5 +74,5 @@ class AlexNetOWT_BN(nn.Module):
 
 
 def alexnet(**kwargs):
-    num_classes = getattr(kwargs, 'num_classes', 1000)
+    num_classes = kwargs.get( 'num_classes', 1000)
     return AlexNetOWT_BN(num_classes)

--- a/models/alexnet_binary.py
+++ b/models/alexnet_binary.py
@@ -88,5 +88,5 @@ class AlexNetOWT_BN(nn.Module):
 
 
 def alexnet_binary(**kwargs):
-    num_classes = getattr(kwargs, 'num_classes', 1000)
+    num_classes = kwargs.get( 'num_classes', 1000)
     return AlexNetOWT_BN(num_classes)

--- a/models/vgg_cifar10.py
+++ b/models/vgg_cifar10.py
@@ -65,5 +65,5 @@ class AlexNetOWT_BN(nn.Module):
 
 
 def model(**kwargs):
-    num_classes = getattr(kwargs,'num_classes', 1000)
+    num_classes = kwargs.get( 'num_classes', 1000)
     return AlexNetOWT_BN(num_classes)

--- a/models/vgg_cifar10_binary.py
+++ b/models/vgg_cifar10_binary.py
@@ -76,5 +76,5 @@ class VGG_Cifar10(nn.Module):
 
 
 def vgg_cifar10_binary(**kwargs):
-    num_classes = getattr(kwargs,'num_classes', 10)
+    num_classes = kwargs.get( 'num_classes', 10)
     return VGG_Cifar10(num_classes)


### PR DESCRIPTION
I fix some mistake due to deprecated usage.
Here some error fixed : 

-  ` ` `IndexError: invalid index of a 0-dim tensor. Use tensor.item() to convert a 0-dim tensor to a Python number
` ` `
- ` ` `
  File "main_binary.py", line 233
    target = target.cuda(async=True)
                             ^
SyntaxError: invalid syntax
` ` `
- ` ` `main_binary.py:234: UserWarning: volatile was removed and now has no effect. Use with torch.no_grad():  instead.
  input_var = Variable(inputs.type(args.type), volatile=not training)
` ` `

And I fix some mistake about the Hinge loss label given and Net output dim.